### PR TITLE
remove Bad Apostrophe

### DIFF
--- a/examples/slideshow.html
+++ b/examples/slideshow.html
@@ -10,7 +10,7 @@
     <h1>smartcrop.js slideshow</h1>
     <p><a href="https://github.com/jwagner/smartcrop.js">smartcrop.js</a> is a content aware image cropping library. On this page you can see how it can be
     used to automatically pick crops to create a <a href="http://en.wikipedia.org/wiki/Ken_Burns_effect">Ken Burns</a> effect on images.</p>
-    <p>You can learn more about smartcrop.js on it's <a href="https://github.com/jwagner/smartcrop.js/">github page</a>.</p>
+    <p>You can learn more about smartcrop.js on its <a href="https://github.com/jwagner/smartcrop.js/">github page</a>.</p>
 
     <div id=prev-slide></div>
     <div id=slide>loading, this can take a little while...</div>


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!