### PR TITLE
Add options object to iop.open call

### DIFF
--- a/smartcrop.js
+++ b/smartcrop.js
@@ -88,7 +88,7 @@ smartcrop.crop = function(inputImage, options_, callback) {
   var scale = 1;
   var prescale = 1;
 
-  return iop.open(inputImage).then(function(image) {
+  return iop.open(inputImage, options).then(function(image) {
 
     if (options.width && options.height) {
       scale = min(image.width / options.width, image.height / options.height);

--- a/smartcrop.js
+++ b/smartcrop.js
@@ -84,11 +84,12 @@ smartcrop.crop = function(inputImage, options_, callback) {
   }
 
   var iop = options.imageOperations;
+  var iopOpen = options_.image ? Promise.resolve(options_.image) : iop.open(inputImage, options_);
 
   var scale = 1;
   var prescale = 1;
 
-  return iop.open(inputImage, options_).then(function(image) {
+  return iopOpen.then(function(image) {
 
     if (options.width && options.height) {
       scale = min(image.width / options.width, image.height / options.height);

--- a/smartcrop.js
+++ b/smartcrop.js
@@ -88,7 +88,7 @@ smartcrop.crop = function(inputImage, options_, callback) {
   var scale = 1;
   var prescale = 1;
 
-  return iop.open(inputImage, options).then(function(image) {
+  return iop.open(inputImage, options_).then(function(image) {
 
     if (options.width && options.height) {
       scale = min(image.width / options.width, image.height / options.height);


### PR DESCRIPTION
Some image processors need to know the type of the image in order to open them as a buffer. This is the case with [lwip](https://github.com/EyalAr/lwip#open-an-image).

To make this possible, we could pass the filename (or just the extension) to `smartcrop` as part of the `options` object, and then make it available to `iop.open` as a second argument. That way, the `iop` can decide how best to open the image when `open()` is called.

(Does this make sense? 😅 )