### PR TITLE
Fix bad apostrophe

### DIFF
--- a/examples/testsuite.html
+++ b/examples/testsuite.html
@@ -14,7 +14,7 @@
     page is running just smartcrop.js without any additional face detection. You can play with face detection in the <a href="testbed.html">testbed</a>.
   </p>
   <p>
-    You can learn more about the library on it's <a href="https://github.com/jwagner/smartcrop.js/">github page</a>. You can try it out on your on images using the <a href="testbed.html">testbed</a>.</p>
+    You can learn more about the library on its <a href="https://github.com/jwagner/smartcrop.js/">github page</a>. You can try it out on your on images using the <a href="testbed.html">testbed</a>.</p>
   <p id=perf></p>
   <div><img src=images/flickr/img.jpg></div>
   <div class=testsuite-image-title><a href="https://www.flickr.com/photos/80225884@N06/13318614973/">Selfie</a> by <span class=testsuite-image-attribution><a href="https://29a.ch/">Myself</a> ;)</span></div>


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!