### PR TITLE
Remove invalid named export from typedefs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export interface CropOptions {
   ruleOfThirds?: boolean;
   debug?: boolean;
 }
-export const smartcrop: {
+const smartcrop: {
   crop(image: CanvasImageSource, options: CropOptions): Promise<CropResult>;
 };
 export default smartcrop;


### PR DESCRIPTION
```ts
import { smartcrop } from "smartcrop";
```

doesn’t work in all environments, but

```ts
import smartcrop from "smartcrop";
```

does.